### PR TITLE
Update PathAuto cleaner to use new alias cleaner service.

### DIFF
--- a/src/FileFieldPathsClean.php
+++ b/src/FileFieldPathsClean.php
@@ -34,8 +34,8 @@ class FileFieldPathsClean {
    * @return $string
    */
   protected function pathAutoClean($string) {
-    $pathauto_manager = \Drupal::service('pathauto.manager');
-    $string = $pathauto_manager->cleanString($string);
+    $pathauto_cleaner = \Drupal::service('pathauto.alias_cleaner');
+    $string = $pathauto_cleaner->cleanString($string);
 
     return $string;
   }


### PR DESCRIPTION
PathAuto moved the cleanString method to the AliasCleaner service. Updated FFP to use that service.
